### PR TITLE
Install from Heroku Org

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Currently, you need to have a [Go development environment](http://golang.org/doc
 We intend to provide compiled binary forms of hk for easy installation,
 but this isn't ready yet.
 
-	$ go get github.com/kr/hk
+	$ go get github.com/heroku/hk
 
 ### netrc
 


### PR DESCRIPTION
Simple update to the instructions to install from the Heroku org rather than @kr's.
