### PR TITLE
Added Contributing.md to help stave off unwanted feature requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+# Before making a feature request
+`hk`'s current design follows unix conventions where they are directly applicable.  For example, we do not intend to replicate the `heroku config` command given that we already have `hk env`, `hk set`, and `hk unset`.


### PR DESCRIPTION
Github [automatically links to the `CONTRIBUTING.md` document](https://github.com/blog/1184-contributing-guidelines) at the top of the create issue page.  This provides a way to gently guide armchair product managers in the right direction.

Here's a stub contributing file that might help stave off out of scope feature suggestions like [the one I just submitted](https://github.com/heroku/hk/issues/9) earlier today.

Thanks! :smile: 
