### PR TITLE
Default to 10 initial lines when tailing.

### DIFF
--- a/log.go
+++ b/log.go
@@ -63,9 +63,14 @@ func runLog(cmd *Command, args []string) {
 	}
 
 	v.Dyno = dyno
-	v.Lines = lines
 	v.Source = source
-	v.Tail = lines == -1
+
+	if lines == -1 {
+		v.Tail = true
+		v.Lines = 10
+	} else {
+		v.Lines = lines
+	}
 
 	var session struct {
 		Id         string `json:"id"`


### PR DESCRIPTION
Dumping everything available when tailing with `hk log` is pretty jarring. Mimic `tail(1)` default behavior and provide 10 lines of context.
