### PR TITLE
Add release info and rollback commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,8 @@ var commands = []*Command{
 	cmdApps,
 	cmdDynos,
 	cmdReleases,
+	cmdReleaseInfo,
+	cmdRollback,
 	cmdAddons,
 	cmdScale,
 	cmdRestart,


### PR DESCRIPTION
```
➜ hk help release-info
Usage: hk release-info

release-info shows detailed information about a release.

➜ hk -a hkdist release-info v78
Version:  v78
By:       me@heroku.com
Change:   Removed FAKE config vars.
When:     2013-11-26T22:14:36Z
Id:       8d68c2b3-6178-4f5c-96f0-1234567890
Slug:     e5b1ca08-9625-43b8-8d89-1234567890
```

```
➜ hk help rollback    
Usage: hk rollback <version>

➜ hk -a hkdist rollback v78    
Rolled back to v78 as v85.
```
