### PR TITLE
Batch scale and resize

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"ImportPath": "github.com/bgentry/heroku-go",
-			"Rev": "8b848518cb8ded30d6af15c03697574e7875ded3"
+			"Rev": "4eba41455a5707ef9af074aebf78d3c736fb362a"
 		},
 		{
 			"ImportPath": "github.com/bmizerany/pat",

--- a/Godeps/_workspace/src/github.com/bgentry/heroku-go/app_test.go
+++ b/Godeps/_workspace/src/github.com/bgentry/heroku-go/app_test.go
@@ -30,10 +30,7 @@ const appMarshaled = `{
 	"released_at": "2012-01-01T12:00:00Z",
 	"repo_size": 1,
 	"slug_size": 1,
-	"stack": {
-		"id": "01234567-89ab-cdef-0123-456789abcdef",
-		"name": "cedar"
-	},
+	"stack": "cedar",
 	"updated_at": "2012-01-01T12:00:00Z",
 	"web_url": "http://example.herokuapp.com"
 }`
@@ -54,7 +51,7 @@ func TestAppUnmarshal(t *testing.T) {
 	testStringsEqual(t, "app.Name", "example", app.Name)
 	testStringsEqual(t, "app.Owner.Email", "username@example.com", app.Owner.Email)
 	testStringsEqual(t, "app.Region.Name", "us", app.Region.Name)
-	testStringsEqual(t, "app.Stack.Name", "cedar", app.Stack.Name)
+	testStringsEqual(t, "app.Stack", "cedar", app.Stack)
 }
 
 var appInfoResponse = testnet.TestResponse{

--- a/Godeps/_workspace/src/github.com/bgentry/heroku-go/formation.go
+++ b/Godeps/_workspace/src/github.com/bgentry/heroku-go/formation.go
@@ -69,14 +69,14 @@ func (c *Client) FormationList(appIdentity string, lr *ListRange) ([]Formation, 
 // Array with formation updates. Each element must have "process", the id or
 // name of the process type to be updated, and can optionally update its
 // "quantity" or "size".
-func (c *Client) FormationBatchUpdate(appIdentity string, updates []FormationBatchUpdateOpts) (*Formation, error) {
+func (c *Client) FormationBatchUpdate(appIdentity string, updates []FormationBatchUpdateOpts) ([]Formation, error) {
 	params := struct {
 		Updates []FormationBatchUpdateOpts `json:"updates"`
 	}{
 		Updates: updates,
 	}
-	var formationRes Formation
-	return &formationRes, c.Patch(&formationRes, "/apps/"+appIdentity+"/formation", params)
+	var formationsRes []Formation
+	return formationsRes, c.Patch(&formationsRes, "/apps/"+appIdentity+"/formation", params)
 }
 
 type FormationBatchUpdateOpts struct {

--- a/Godeps/_workspace/src/github.com/bgentry/heroku-go/gen/gen.rb
+++ b/Godeps/_workspace/src/github.com/bgentry/heroku-go/gen/gen.rb
@@ -92,8 +92,13 @@ import (
       <%- if !required.empty? %>
         <%= Erubis::Eruby.new(LINK_PARAMS_TEMPLATE).result({modelname: key, link: link, required: required, optional: optional}).strip %>
       <%- end %>
-      var <%= variablecase(key + '-res') %> <%= hasCustomType ? titlecase(key) : "map[string]string" %>
-      return <%= "&" if hasCustomType%><%= variablecase(key + '-res') %>, c.Patch(&<%= variablecase(key + '-res') %>, <%= path %>, <%= postval %>)
+      <%- if link["title"].include?("Batch") %>
+        var <%= variablecase(key + 's-res') %> []<%= titlecase(key) %>
+        return <%= variablecase(key + 's-res') %>, c.Patch(&<%= variablecase(key + 's-res') %>, <%= path %>, <%= postval %>)
+      <%- else %>
+        var <%= variablecase(key + '-res') %> <%= hasCustomType ? titlecase(key) : "map[string]string" %>
+        return <%= "&" if hasCustomType%><%= variablecase(key + '-res') %>, c.Patch(&<%= variablecase(key + '-res') %>, <%= path %>, <%= postval %>)
+      <%- end %>
     <%- when "instances" %>
       req, err := c.NewRequest("GET", <%= path %>, nil)
       if err != nil {
@@ -327,7 +332,11 @@ def return_values_from_link(modelname, link)
     when "instances"
       "([]#{titlecase(modelname)}, error)"
     else
-      "(*#{titlecase(modelname)}, error)"
+      if link["title"].include?("Batch")
+        "([]#{titlecase(modelname)}, error)"
+      else
+        "(*#{titlecase(modelname)}, error)"
+      end
     end
   end
 end

--- a/scale_test.go
+++ b/scale_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+)
+
+var parseScaleTests = []struct {
+	in     string
+	pstype string
+	qty    int
+	size   string
+	err    error
+}{
+	{"web=5", "web", 5, "", nil},
+	{"bg_worker=50:1X", "bg_worker", 50, "1X", nil},
+	{"web=:2X", "web", -1, "2X", nil},
+	{"web=1X", "web", -1, "1X", nil},
+	{"web=1x", "web", -1, "1X", nil},
+	{"web=1X:5", "web", -1, "", errInvalidScaleArg},
+	{"web", "", -1, "", errInvalidScaleArg},
+	{"web=", "web", -1, "", errInvalidScaleArg},
+	{"web =", "", -1, "", errInvalidScaleArg},
+	{"web=1X: 5", "", -1, "", errInvalidScaleArg},
+}
+
+func TestParseScaleArg(t *testing.T) {
+	for i, pt := range parseScaleTests {
+		pstype, qty, size, err := parseScaleArg(pt.in)
+		if pstype != pt.pstype {
+			t.Errorf("%d. parseScaleArg(%q).pstype => %q, want %q", i, pt.in, pstype, pt.pstype)
+		}
+		if qty != pt.qty {
+			t.Errorf("%d. parseScaleArg(%q).qty => %d, want %d", i, pt.in, qty, pt.qty)
+		}
+		if size != pt.size {
+			t.Errorf("%d. parseScaleArg(%q).size => %q, want %q", i, pt.in, size, pt.size)
+		}
+		if err != pt.err {
+			t.Errorf("%d. parseScaleArg(%q).err => %q, want %q", i, pt.in, err, pt.err)
+		}
+	}
+}


### PR DESCRIPTION
Update formation for multiple process types at once from a single command, including both quantity and size (horizontal + vertical scale).

```
➜  ./hk help scale
Usage: hk scale <type>=[<qty>]:[<size>]...

Scale changes the quantity of dynos (horizontal scale) and the
dyno size (vertical scale) for each process type.

Example:

    $ hk scale web=2 worker=5

    $ hk scale web=2:1X worker=5:2X

    $ hk scale web=2X worker=:1X
```
