### PR TITLE
add support for heroku.remote

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ func remoteFromGit() string {
 	if err != nil {
 		return "heroku"
 	}
-	return strings.Trim(string(b), "\r\n ")
+	return strings.TrimSpace(string(b))
 }
 
 func appFromGitRemote(remote string) (string, error) {
@@ -249,7 +249,7 @@ func appFromGitRemote(remote string) (string, error) {
 		return "", err
 	}
 
-	out := strings.Trim(string(b), "\r\n ")
+	out := strings.TrimSpace(string(b))
 
 	if !strings.HasPrefix(out, gitURLPre) || !strings.HasSuffix(out, gitURLSuf) {
 		return "", fmt.Errorf("could not find app name in " + remote + " git remote")


### PR DESCRIPTION
Try to find an `heroku.remote` in git configuration and fallback to `heroku` remote, so that we support [multiple environments for an app](https://devcenter.heroku.com/articles/multiple-environments).
