### PR TITLE
app transfer commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,6 +129,11 @@ var commands = []*Command{
 	cmdGet,
 	cmdCreds,
 	cmdOpen,
+	cmdTransfer,
+	cmdTransfers,
+	cmdTransferAccept,
+	cmdTransferDecline,
+	cmdTransferCancel,
 	cmdURL,
 
 	// unlisted

--- a/transfer.go
+++ b/transfer.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"github.com/bgentry/heroku-go"
+	"io"
+	"os"
+	"text/tabwriter"
+)
+
+var cmdTransfer = &Command{
+	Run:   runTransfer,
+	Usage: "transfer <email>",
+	Short: "transfer app ownership to a collaborator" + extra,
+}
+
+func runTransfer(cmd *Command, args []string) {
+	if len(args) != 1 {
+		cmd.printUsage()
+		os.Exit(2)
+	}
+	recipient := args[0]
+	_, err := client.AppTransferCreate(mustApp(), recipient)
+	must(err)
+}
+
+var cmdTransfers = &Command{
+	Run:   runTransfers,
+	Usage: "transfers [-l]",
+	Short: "list existing app transfers" + extra,
+}
+
+func init() {
+	cmdTransfers.Flag.BoolVar(&flagLong, "l", false, "long listing")
+}
+
+func runTransfers(cmd *Command, args []string) {
+	transfers, err := client.AppTransferList(nil)
+	must(err)
+
+	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
+	defer w.Flush()
+	for i := range transfers {
+		listTransfer(w, transfers[i])
+	}
+}
+
+func listTransfer(w io.Writer, t heroku.AppTransfer) {
+	if flagLong {
+		listRec(w,
+			t.App.Name,
+			abbrev(t.Owner.Email, 10),
+			abbrev(t.Recipient.Email, 10),
+			t.State,
+			prettyTime{t.UpdatedAt},
+		)
+	} else {
+		fmt.Fprintln(w, t.App.Name)
+	}
+}
+
+var cmdTransferAccept = &Command{
+	Run:   runTransferAccept,
+	Usage: "transfer-accept",
+	Short: "accept an inbound app transfer" + extra,
+}
+
+func runTransferAccept(cmd *Command, args []string) {
+	transferId := mustLookupTransfer(mustApp())
+	must(updateTransferState(transferId, "accepted"))
+}
+
+var cmdTransferDecline = &Command{
+	Run:   runTransferDecline,
+	Usage: "transfer-decline",
+	Short: "decline an inbound app transfer" + extra,
+}
+
+func runTransferDecline(cmd *Command, args []string) {
+	transferId := mustLookupTransfer(mustApp())
+	must(updateTransferState(transferId, "declined"))
+}
+
+var cmdTransferCancel = &Command{
+	Run:   runTransferCancel,
+	Usage: "transfer-cancel",
+	Short: "cancel an outbound app transfer" + extra,
+}
+
+func runTransferCancel(cmd *Command, args []string) {
+	must(client.AppTransferDelete(mustLookupTransfer(mustApp())))
+}
+
+func mustLookupTransfer(appname string) string {
+	// If the API starts allowing app identity instead of requiring
+	// app-transfer UUID, this lookup will be unnecessary.
+	transfers, err := client.AppTransferList(nil)
+	must(err)
+	var transferId string
+	for i := range transfers {
+		if transfers[i].App.Name == appname {
+			transferId = transfers[i].Id
+			break
+		}
+	}
+	if transferId == "" {
+		fmt.Printf("no pending transfer for app %s\n", appname)
+		os.Exit(1)
+	}
+	return transferId
+}
+
+func updateTransferState(transferId, newstate string) error {
+	_, err := client.AppTransferUpdate(transferId, newstate)
+	return err
+}


### PR DESCRIPTION
```
➜ hk -a testtransferapp transfer raulb@heroku.com

➜ hk -a testtransferapp transfer-decline

➜ hk -a testtransferapp transfer-accept

➜ hk transfers -l                                
testtransferapp  raulb@her…  b@heroku.…  accepted  Dec  5 15:24
testtransferapp  raulb@her…  b@heroku.…  declined  Dec  5 15:23
testtransferapp  b@heroku.…  raulb@her…  pending   Dec  5 15:29
testtransferapp  b@heroku.…  raulb@her…  accepted  Dec  5 15:22

➜ hk -a testtransferapp transfer-cancel

➜ hk transfers -l                      
testtransferapp  raulb@her…  b@heroku.…  declined  Dec  5 15:23
testtransferapp  b@heroku.…  raulb@her…  pending   Dec  5 15:29
testtransferapp  b@heroku.…  raulb@her…  accepted  Dec  5 15:22
```

IMO, it's starting to become clear that these state-changing commands should have some sort of confirmation as output. But that's a separate issue we'll have to tackle.

/cc @raulb @max 
