### PR TITLE
Always show long format (table) lists

### DIFF
--- a/addons.go
+++ b/addons.go
@@ -13,32 +13,21 @@ import (
 
 var cmdAddons = &Command{
 	Run:      runAddons,
-	Usage:    "addons [-l] [resource...]",
+	Usage:    "addons [<provider>:<plan>...]",
 	Category: "add-on",
 	Short:    "list addons",
 	Long: `
 Lists addons.
 
-Options:
-
-    -l       long listing
-
-Long listing shows the type of the addon, owner, name of the
-resource, and the config var it's attached to.
-
 Examples:
 
     $ hk addons
-    DATABASE_URL
-    REDIS_URL
+    heroku-postgresql:crane
+    pgbackups:plus
 
-    $ hk addons -l REDIS_URL
-    redistogo:nano  me  soaring-ably-1234  REDIS_URL
+    $ hk addons pgbackups:plus
+    pgbackups:plus
 `,
-}
-
-func init() {
-	cmdAddons.Flag.BoolVar(&flagLong, "l", false, "long listing")
 }
 
 func runAddons(cmd *Command, names []string) {
@@ -95,15 +84,7 @@ func addonMatch(m *mergedAddon, a []string) bool {
 }
 
 func listAddon(w io.Writer, m *mergedAddon) {
-	if flagLong {
-		listRec(w,
-			m.Type,
-			abbrev(m.Owner, 10),
-			m.Id,
-		)
-	} else {
-		fmt.Fprintln(w, m.String())
-	}
+	fmt.Fprintln(w, m.String())
 }
 
 type mergedAddon struct {
@@ -141,7 +122,7 @@ func getMergedAddons(appname string) []*mergedAddon {
 }
 
 func mergeAddons(app *heroku.App, addons []heroku.Addon) (ms []*mergedAddon) {
-	// Type, Name, Owner
+	// Type, Owner, Id
 	for _, a := range addons {
 		m := new(mergedAddon)
 		ms = append(ms, m)

--- a/apps.go
+++ b/apps.go
@@ -12,37 +12,23 @@ import (
 
 var cmdApps = &Command{
 	Run:      runApps,
-	Usage:    "apps [-l] [app...]",
+	Usage:    "apps [app...]",
 	Category: "app",
 	Short:    "list apps",
 	Long: `
-Lists all apps.
-
-Options:
-
-    -l       long listing
-
-Long listing for shows the owner, slug size, last release time
-(or time the app was created, if it's never been released), and
-the app name.
+Lists apps. Shows the app name, owner, slug size, and last
+release time (or time the app was created, if it's never been
+released).
 
 Examples:
 
-	$ hk apps
-	myapp
-	myapp2
+    $ hk apps
+    myapp   me  1234k  Jan 2 12:34
+    myapp2  me  4567k  Jan 2 12:34
 
-	$ hk apps myapp
-	myapp
-
-	$ hk apps -l
-	app  me  1234k  Jan 2 12:34  myapp
-	app  me  4567k  Jan 2 12:34  myapp2
+    $ hk apps myapp
+    myapp  me  1234k  Jan 2 12:34
 `,
-}
-
-func init() {
-	cmdApps.Flag.BoolVar(&flagLong, "l", false, "long listing")
 }
 
 func runApps(cmd *Command, names []string) {
@@ -116,25 +102,20 @@ func abbrevEmailApps(apps []heroku.App) {
 }
 
 func listApp(w io.Writer, a heroku.App) {
-	if flagLong {
-		size := 0
-		if a.SlugSize != nil {
-			size = *a.SlugSize
-		}
-		t := a.CreatedAt
-		if a.ReleasedAt != nil {
-			t = *a.ReleasedAt
-		}
-		listRec(w,
-			"app",
-			abbrev(a.Owner.Email, 10),
-			fmt.Sprintf("%6dk", (size+501)/(1000)),
-			prettyTime{t},
-			a.Name,
-		)
-	} else {
-		fmt.Fprintln(w, a.Name)
+	size := 0
+	if a.SlugSize != nil {
+		size = *a.SlugSize
 	}
+	t := a.CreatedAt
+	if a.ReleasedAt != nil {
+		t = *a.ReleasedAt
+	}
+	listRec(w,
+		a.Name,
+		abbrev(a.Owner.Email, 10),
+		fmt.Sprintf("%6dk", (size+501)/(1000)),
+		prettyTime{t},
+	)
 }
 
 type appsByName []heroku.App

--- a/domains.go
+++ b/domains.go
@@ -10,32 +10,18 @@ import (
 
 var cmdDomains = &Command{
 	Run:      runDomains,
-	Usage:    "domains [-l]",
+	Usage:    "domains",
 	Category: "domain",
 	Short:    "list domains",
 	Long: `
 Lists domains.
-
-Options:
-
-    -l       long listing
-
-Long listing for shows the name, state, age, and command.
 
 Examples:
 
     $ hk domains
     test.herokuapp.com
     www.test.com
-
-    $ hk domains -l
-    test.herokuapp.com  Jun 12 18:28  01234567-89ab-cdef-0123-456789abcdef
-    www.test.com        Jun 13 18:14  abcdef01-89ab-cdef-9876-543210fedcba
 `,
-}
-
-func init() {
-	cmdDomains.Flag.BoolVar(&flagLong, "l", false, "long listing")
 }
 
 func runDomains(cmd *Command, args []string) {
@@ -50,15 +36,7 @@ func runDomains(cmd *Command, args []string) {
 	must(err)
 
 	for _, d := range domains {
-		if flagLong {
-			listRec(w,
-				d.Hostname,
-				prettyTime{d.CreatedAt},
-				d.Id,
-			)
-		} else {
-			fmt.Fprintln(w, d.Hostname)
-		}
+		fmt.Fprintln(w, d.Hostname)
 	}
 }
 

--- a/dynos.go
+++ b/dynos.go
@@ -15,38 +15,23 @@ import (
 
 var cmdDynos = &Command{
 	Run:      runDynos,
-	Usage:    "dynos [-l] [name...]",
+	Usage:    "dynos [name...]",
 	Category: "dyno",
 	Short:    "list dynos",
 	Long: `
-Lists dynos.
-
-Options:
-
-    -l       long listing
-
-Long listing shows the name, state, age, and command.
+Lists dynos. Shows the name, state, age, and command.
 
 Examples:
 
     $ hk dynos
-    run.3794
-    web.1
-    web.2
-
-    $ hk dynos web
-    web.1
-    web.2
-
-    $ hk dynos -l
     run.3794  up   1m  bash
     web.1     up  15h  "blog /app /tmp/dst"
     web.2     up   8h  "blog /app /tmp/dst"
-`,
-}
 
-func init() {
-	cmdDynos.Flag.BoolVar(&flagLong, "l", false, "long listing")
+    $ hk dynos web
+    web.1     up  15h  "blog /app /tmp/dst"
+    web.2     up   8h  "blog /app /tmp/dst"
+`,
 }
 
 func runDynos(cmd *Command, names []string) {
@@ -83,16 +68,12 @@ func listDynos(w io.Writer, names []string) {
 }
 
 func listDyno(w io.Writer, d *heroku.Dyno) {
-	if flagLong {
-		listRec(w,
-			d.Name,
-			d.State,
-			prettyDuration{dynoAge(d)},
-			maybeQuote(d.Command),
-		)
-	} else {
-		fmt.Fprintln(w, d.Name)
-	}
+	listRec(w,
+		d.Name,
+		d.State,
+		prettyDuration{dynoAge(d)},
+		maybeQuote(d.Command),
+	)
 }
 
 // quotes s as a json string if it contains any weird chars

--- a/hkdist/public/styleguide.html
+++ b/hkdist/public/styleguide.html
@@ -90,7 +90,7 @@
             },
             {
               "root": "apps",
-              "arguments": "[-l] [app...]",
+              "arguments": "[app...]",
               "comment": "list apps"
             },
             {
@@ -145,7 +145,7 @@
             },
             {
               "root": "transfers",
-              "arguments": "[-l]",
+              "arguments": "",
               "comment": "list existing app transfers (extra)"
             },
             {
@@ -160,7 +160,7 @@
           "commands": [
             {
               "root": "dynos",
-              "arguments": "[-l] [name...]",
+              "arguments": "[name...]",
               "comment": "list dynos"
             },
             {
@@ -190,7 +190,7 @@
             },
             {
               "root": "releases",
-              "arguments": "[-l] [name...]",
+              "arguments": "[\u003cname\u003e...]",
               "comment": "list releases"
             },
             {
@@ -220,7 +220,7 @@
             },
             {
               "root": "addons",
-              "arguments": "[-l] [resource...]",
+              "arguments": "[\u003cprovider\u003e:\u003cplan\u003e...]",
               "comment": "list addons"
             }
           ],
@@ -265,7 +265,7 @@
             },
             {
               "root": "domains",
-              "arguments": "[-l]",
+              "arguments": "",
               "comment": "list domains"
             }
           ],

--- a/main.go
+++ b/main.go
@@ -143,7 +143,6 @@ var commands = []*Command{
 
 var (
 	flagApp   string
-	flagLong  bool
 	client    heroku.Client
 	hkAgent   = "hk/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 	userAgent = hkAgent + " " + heroku.DefaultUserAgent

--- a/transfer.go
+++ b/transfer.go
@@ -27,13 +27,9 @@ func runTransfer(cmd *Command, args []string) {
 
 var cmdTransfers = &Command{
 	Run:      runTransfers,
-	Usage:    "transfers [-l]",
+	Usage:    "transfers",
 	Category: "app",
 	Short:    "list existing app transfers" + extra,
-}
-
-func init() {
-	cmdTransfers.Flag.BoolVar(&flagLong, "l", false, "long listing")
 }
 
 func runTransfers(cmd *Command, args []string) {
@@ -48,17 +44,13 @@ func runTransfers(cmd *Command, args []string) {
 }
 
 func listTransfer(w io.Writer, t heroku.AppTransfer) {
-	if flagLong {
-		listRec(w,
-			t.App.Name,
-			abbrev(t.Owner.Email, 10),
-			abbrev(t.Recipient.Email, 10),
-			t.State,
-			prettyTime{t.UpdatedAt},
-		)
-	} else {
-		fmt.Fprintln(w, t.App.Name)
-	}
+	listRec(w,
+		t.App.Name,
+		abbrev(t.Owner.Email, 10),
+		abbrev(t.Recipient.Email, 10),
+		t.State,
+		prettyTime{t.UpdatedAt},
+	)
 }
 
 var cmdTransferAccept = &Command{


### PR DESCRIPTION
Always show long format (table) lists when there is more than one useful column to show. Remove the `-l` long flag.
