### PR TITLE
bash-tab-completion-jkakar

### DIFF
--- a/contrib/hk-bash-completion.sh
+++ b/contrib/hk-bash-completion.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+_hk_commands()
+{
+    hk help commands|cut -f 2 -d ' '
+}
+
+_hk()
+{
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+    if [ $COMP_CWORD -eq 1 ]; then
+        COMPREPLY=( $( compgen -W "$(_hk_commands)" $cur ) )
+    elif [ $COMP_CWORD -eq 2 ]; then
+        case "$prev" in
+        help)
+            COMPREPLY=( $( compgen -W "$(_hk_commands)" $cur ) )
+            ;;
+        esac
+    fi
+}
+
+complete -F _hk -o default hk


### PR DESCRIPTION
- Add a tab completion script for bash.

I'm not sure how to get this installed, but for now, being able to
`source contrib/hk-tab-completion.sh` is making `hk` more enjoyable to
use.
