### PR TITLE
Fix check addon message

### DIFF
--- a/addons.go
+++ b/addons.go
@@ -188,7 +188,6 @@ Examples:
 `,
 }
 
-// Couldn't find that add-on. Please choose an addon name from addons.
 func runAddonOpen(cmd *Command, args []string) {
 	appname := mustApp()
 	if len(args) != 1 {


### PR DESCRIPTION
Need to check `hk addons`, not `hk addon-list`. Also removed a comment that seemed misplaced and unnecessary.
