### PR TITLE
Remove `godep go get` command from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ hk will set these environment variables for a plugin:
 
 ### Development
 
-hk requires Go 1.1 or later and [godep](https://github.com/kr/godep).
+hk requires Go 1.1 or later and uses [Godep](https://github.com/kr/godep) to manage dependencies.
 
 	$ cd hk
 	$ mate main.go


### PR DESCRIPTION
This subcommand appears to have been deprecated, and doesn't seem to be
required to get `hk` to build:

```
Any go tool command can run this way, but "godep go get"
is unnecessary and has been disabled. Instead, use
"godep go install".
```
