### PR TITLE
Move homePath() and netrcFilename to platform files.

### DIFF
--- a/unix.go
+++ b/unix.go
@@ -3,9 +3,16 @@
 package main
 
 import (
+	"os"
 	"syscall"
 )
 
+const netrcFilename = ".netrc"
+
 func sysExec(path string, args []string, env []string) error {
 	return syscall.Exec(path, args, env)
+}
+
+func homePath() string {
+	return os.Getenv("HOME")
 }

--- a/util.go
+++ b/util.go
@@ -14,23 +14,15 @@ import (
 	"github.com/mgutz/ansi"
 )
 
-func homePath() string {
-	// user.Current() requires cgo and thus doesn't work with cross-compiling.
-	// This following is an alternative that matches how the Heroku Toolbelt
-	// works, though per @fdr it may not be correct for all cases (when users have
-	// modified their home dir).
-	//
-	// http://stackoverflow.com/questions/7922270/obtain-users-home-directory
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-		return home
-	}
-	return os.Getenv("HOME")
-}
-
+// user.Current() requires cgo and thus doesn't work with cross-compiling.
+// The following is an alternative that matches how the Heroku Toolbelt
+// works, though per @fdr it may not be correct for all cases (when users have
+// modified their home dir).
+//
+// homePath() is defined in the platform-specific source files unix.go and
+// windows.go.
+//
+// http://stackoverflow.com/questions/7922270/obtain-users-home-directory
 func hkHome() string {
 	return filepath.Join(homePath(), ".hk")
 }
@@ -40,11 +32,7 @@ func netrcPath() string {
 		return s
 	}
 
-	filename := ".netrc"
-	if runtime.GOOS == "windows" {
-		filename = "_netrc"
-	}
-	return filepath.Join(homePath(), filename)
+	return filepath.Join(homePath(), netrcFilename)
 }
 
 // exists returns whether the given file or directory exists or not

--- a/windows.go
+++ b/windows.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 )
 
+const netrcFilename = "_netrc"
+
 func sysExec(path string, args []string, env []string) error {
 	cmd := exec.Command(path, args...)
 	cmd.Env = env
@@ -19,4 +21,12 @@ func sysExec(path string, args []string, env []string) error {
 	}
 	os.Exit(0)
 	return nil
+}
+
+func homePath() string {
+	home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	if home == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	return home
 }


### PR DESCRIPTION
Gets them properly defined at build time instead of switching on runtime.GOOS at runtime.

Re [this comment](https://github.com/heroku/hk/commit/7882c4ee5fc6e522ab085fcdba7a37ccaaa8bdaa#commitcomment-5150093) from @kr.
