### PR TITLE
Rename sshkey-add to key-add. Add keys and key-remove commands

### DIFF
--- a/hkdist/public/styleguide.html
+++ b/hkdist/public/styleguide.html
@@ -126,7 +126,17 @@
             {
               "root": "key-add",
               "arguments": "[<public-key-file>]",
-              "comment": "add ssh public key"
+              "comment": "add ssh public key (extra)"
+            },
+            {
+              "root": "key-remove",
+              "arguments": "<fingerprint>",
+              "comment": "remove an ssh public key (extra)"
+            },
+            {
+              "root": "keys",
+              "arguments": "",
+              "comment": "list ssh public keys (extra)"
             }
           ],
           "title": "account"

--- a/keys.go
+++ b/keys.go
@@ -9,17 +9,53 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"text/tabwriter"
 )
 
 var (
 	sshPubKeyPath string
 )
 
+var cmdKeys = &Command{
+	Run:      runKeys,
+	Usage:    "keys",
+	Category: "account",
+	Short:    "list ssh public keys" + extra,
+	Long: `
+Keys lists SSH public keys associated with your Heroku account.
+
+Examples:
+
+    $ hk keys
+    5e:67:40:b6:79:db:56:47:cd:3a:a7:65:ab:ed:12:34  user@test.com
+`,
+}
+
+func runKeys(cmd *Command, args []string) {
+	if len(args) != 0 {
+		cmd.printUsage()
+		os.Exit(2)
+	}
+
+	keys, err := client.KeyList(nil)
+	must(err)
+
+	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
+	defer w.Flush()
+
+	for i := range keys {
+		listRec(w,
+			keys[i].Fingerprint,
+			keys[i].Email,
+		)
+	}
+}
+
 var cmdKeyAdd = &Command{
 	Run:      runKeyAdd,
 	Usage:    "key-add [<public-key-file>]",
 	Category: "account",
-	Short:    "add ssh public key",
+	Short:    "add ssh public key" + extra,
 	Long: `
 Command key-add adds an ssh public key to your Heroku account.
 
@@ -98,4 +134,31 @@ type privKeyError string
 
 func (e privKeyError) Error() string {
 	return "appears to be a private key: " + string(e)
+}
+
+var cmdKeyRemove = &Command{
+	Run:      runKeyRemove,
+	Usage:    "key-remove <fingerprint>",
+	Category: "account",
+	Short:    "remove an ssh public key" + extra,
+	Long: `
+Command key-remove removes an ssh public key from your Heroku account.
+
+Examples:
+
+    $ hk key-remove 5e:67:40:b6:79:db:56:47:cd:3a:a7:65:ab:ed:12:34
+    Key 5e:67:40:b6:79:db… removed.
+`,
+}
+
+func runKeyRemove(cmd *Command, args []string) {
+	if len(args) != 1 {
+		cmd.printUsage()
+		os.Exit(2)
+	}
+	fingerprint := args[0]
+
+	err := client.KeyDelete(fingerprint)
+	must(err)
+	log.Printf("Key %s removed.", abbrev(fingerprint, 18))
 }

--- a/main.go
+++ b/main.go
@@ -103,7 +103,6 @@ var commands = []*Command{
 	cmdDomains,
 	cmdDomainAdd,
 	cmdDomainRemove,
-	cmdKeyAdd,
 	cmdVersion,
 	cmdHelp,
 
@@ -128,6 +127,9 @@ var commands = []*Command{
 	cmdFeatureEnable,
 	cmdFeatureDisable,
 	cmdGet,
+	cmdKeys,
+	cmdKeyAdd,
+	cmdKeyRemove,
 	cmdMaintenance,
 	cmdMaintenanceEnable,
 	cmdMaintenanceDisable,


### PR DESCRIPTION
Usage examples should be self-explanatory:

``` bash
$ hk keys
5e:67:40:b6:79:db:56:47:cd:3a:a7:65:ab:ed:12:34  user@test.com

$ hk key-remove 5e:67:40:b6:79:db:56:47:cd:3a:a7:65:ab:ed:12:34
Key 5e:67:40:b6:79:db… removed.
```
