### PR TITLE
Move hk credential and client management to a package: hkclient

### DIFF
--- a/hkclient/client.go
+++ b/hkclient/client.go
@@ -1,0 +1,92 @@
+package hkclient
+
+import (
+	"crypto/tls"
+	"github.com/bgentry/heroku-go"
+	"github.com/heroku/hk/postgresql"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+type Clients struct {
+	ApiURL string
+	Client *heroku.Client
+
+	PgClient *postgresql.Client
+}
+
+func New(nrc *NetRc, agent string) (*Clients, error) {
+	userAgent := agent + " " + heroku.DefaultUserAgent
+	ste := Clients{}
+
+	disableSSLVerify := false
+	ste.ApiURL = heroku.DefaultAPIURL
+	if s := os.Getenv("HEROKU_API_URL"); s != "" {
+		ste.ApiURL = s
+		disableSSLVerify = true
+	}
+
+	apiURL, err := url.Parse(ste.ApiURL)
+	if err != nil {
+		return nil, err
+	}
+
+	user, pass, err := nrc.GetCreds(apiURL)
+	if err != nil {
+		return nil, err
+	}
+
+	debug := os.Getenv("HKDEBUG") != ""
+	ste.Client = &heroku.Client{
+		URL:       ste.ApiURL,
+		Username:  user,
+		Password:  pass,
+		UserAgent: userAgent,
+		Debug:     debug,
+	}
+	ste.PgClient = &postgresql.Client{
+		Username:  user,
+		Password:  pass,
+		UserAgent: userAgent,
+		Debug:     debug,
+	}
+
+	if disableSSLVerify || os.Getenv("HEROKU_SSL_VERIFY") == "disable" {
+		tr := http.DefaultTransport.(*http.Transport)
+		tr.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+
+		ste.Client.HTTP = &http.Client{Transport: tr}
+		ste.PgClient.HTTP = &http.Client{Transport: tr}
+	}
+	if s := os.Getenv("HEROKU_POSTGRESQL_HOST"); s != "" {
+		ste.PgClient.StarterURL = "https://" + s +
+			".herokuapp.com" + postgresql.DefaultAPIPath
+
+		ste.PgClient.URL = "https://" + s + ".herokuapp.com" +
+			postgresql.DefaultAPIPath
+	}
+	if s := os.Getenv("SHOGUN"); s != "" {
+		ste.PgClient.URL = "https://shogun-" + s +
+			".herokuapp.com" + postgresql.DefaultAPIPath
+	}
+	ste.Client.AdditionalHeaders = http.Header{}
+	ste.PgClient.AdditionalHeaders = http.Header{}
+	for _, h := range strings.Split(os.Getenv("HKHEADER"), "\n") {
+		if i := strings.Index(h, ":"); i >= 0 {
+			ste.Client.AdditionalHeaders.Set(
+				strings.TrimSpace(h[:i]),
+				strings.TrimSpace(h[i+1:]),
+			)
+			ste.PgClient.AdditionalHeaders.Set(
+				strings.TrimSpace(h[:i]),
+				strings.TrimSpace(h[i+1:]),
+			)
+		}
+	}
+
+	return &ste, nil
+}

--- a/hkclient/creds.go
+++ b/hkclient/creds.go
@@ -1,0 +1,75 @@
+package hkclient
+
+import (
+	"fmt"
+	"github.com/bgentry/go-netrc/netrc"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+)
+
+type NetRc struct {
+	netrc.Netrc
+}
+
+func netRcPath() string {
+	if s := os.Getenv("NETRC_PATH"); s != "" {
+		return s
+	}
+
+	return filepath.Join(homePath(), netrcFilename)
+}
+
+func LoadNetRc() (nrc *NetRc, err error) {
+	onrc, err := netrc.ParseFile(netRcPath())
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetRc{*onrc}, nil
+}
+
+func (nrc *NetRc) GetCreds(apiURL *url.URL) (user, pass string, err error) {
+	if err != nil {
+		return "", "", fmt.Errorf("invalid API URL: %s", err)
+	}
+	if apiURL.Host == "" {
+		return "", "", fmt.Errorf("missing API host: %s", apiURL)
+	}
+	if apiURL.User != nil {
+		pw, _ := apiURL.User.Password()
+		return apiURL.User.Username(), pw, nil
+	}
+
+	m := nrc.FindMachine(apiURL.Host)
+	if m == nil {
+		return "", "", nil
+	}
+	return m.Login, m.Password, nil
+}
+
+func (nrc *NetRc) SaveCreds(host, user, pass string) error {
+	m := nrc.FindMachine(host)
+	if m == nil || m.IsDefault() {
+		m = nrc.NewMachine(host, user, pass, "")
+	}
+	m.UpdateLogin(user)
+	m.UpdatePassword(pass)
+
+	body, err := nrc.MarshalText()
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(netRcPath(), body, 0600)
+}
+
+func (nrc *NetRc) RemoveCreds(host string) error {
+	nrc.RemoveMachine(host)
+
+	body, err := nrc.MarshalText()
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(netRcPath(), body, 0600)
+}

--- a/hkclient/unix.go
+++ b/hkclient/unix.go
@@ -1,0 +1,11 @@
+// +build darwin freebsd linux netbsd openbsd
+
+package hkclient
+
+import "os"
+
+const netrcFilename = ".netrc"
+
+func homePath() string {
+	return os.Getenv("HOME")
+}

--- a/hkclient/windows.go
+++ b/hkclient/windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package hkclient
+
+const netrcFilename = "_netrc"
+
+func homePath() string {
+	home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	if home == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	return home
+}


### PR DESCRIPTION
When writing hk plugins or a lot of small client software, figuring
out how to get credentials is a burden.

To help with this, move all the credential and HTTP endpoint discovery
and configuration logic into a package that can be imported elsewhere,
with the explicit goal of with having closely-coupled parity with
'hk'.
