### PR TITLE
add pg-unfollow command

### DIFF
--- a/hkdist/public/styleguide.html
+++ b/hkdist/public/styleguide.html
@@ -454,6 +454,11 @@
               "comment": "list Heroku Postgres databases (extra)"
             },
             {
+              "root": "pg-unfollow",
+              "arguments": "[-a <app>] <dbname>",
+              "comment": "stop a replica postgres database from following (extra)"
+            },
+            {
               "root": "psql",
               "arguments": "[-a <app>] [-c <command>] [<dbname>]",
               "comment": "open a psql shell to a Heroku Postgres database (extra)"

--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ var commands = []*Command{
 	cmdOpen,
 	cmdPgList,
 	cmdPgInfo,
+	cmdPgUnfollow,
 	cmdPsql,
 	cmdRegions,
 	cmdStatus,

--- a/pg_helper.go
+++ b/pg_helper.go
@@ -102,6 +102,49 @@ func newPgAddonMap(addons []heroku.Addon, appConf map[string]string) pgAddonMap 
 	return pgAddonMap{m, appConf}
 }
 
+func mustGetDBInfoAndAddonMap(addonName, appname string) (postgresql.DB, postgresql.DBInfo, pgAddonMap) {
+	// list all addons
+	addons, err := client.AddonList(appname, nil)
+	must(err)
+
+	// locate specific addon
+	var addon *heroku.Addon
+	for i := range addons {
+		if addons[i].Name == addonName {
+			addon = &addons[i]
+			break
+		}
+	}
+	if addon == nil {
+		printFatal("addon %s not found", addonName)
+	}
+
+	// fetch app's config concurrently in case we need to resolve DB names
+	var appConf map[string]string
+	confch := make(chan map[string]string, 1)
+	errch := make(chan error, 1)
+	go func(appname string) {
+		if config, err := client.ConfigVarInfo(appname); err != nil {
+			errch <- err
+		} else {
+			confch <- config
+		}
+	}(appname)
+
+	db := pgclient.NewDB(addon.ProviderId, addon.Plan.Name)
+	dbi, err := db.Info()
+	must(err)
+
+	select {
+	case err := <-errch:
+		printFatal(err.Error())
+	case appConf = <-confch:
+	}
+
+	addonMap := newPgAddonMap(addons, appConf)
+	return db, dbi, addonMap
+}
+
 type fullDBInfo struct {
 	Name     string
 	DBInfo   postgresql.DBInfo


### PR DESCRIPTION
Unfollow a Heroku Postgres database:

```
$ hk pg-unfollow rose                  
warning: heroku-postgresql-rose on myapp will permanently stop following heroku-postgresql-cyan.
warning: This cannot be undone. Please type "rose" to continue:
> rose
Unfollowed heroku-postgresql-rose on myapp.
```

I also pulled out some shared logic into `mustGetDBInfoAndAddonMap()`, which will likely be applicable to some other `pg-*` commands
