### PR TITLE
login command no longer takes email as an arg

### DIFF
--- a/hkdist/public/styleguide.html
+++ b/hkdist/public/styleguide.html
@@ -379,6 +379,11 @@
               "comment": "make a single API request (extra)"
             },
             {
+              "root": "commands",
+              "arguments": "",
+              "comment": "list all commands with usage"
+            },
+            {
               "root": "creds",
               "arguments": "",
               "comment": "show credentials (extra)"
@@ -395,7 +400,7 @@
             },
             {
               "root": "login",
-              "arguments": "<email>",
+              "arguments": "",
               "comment": "log in to your Heroku account (extra)"
             },
             {


### PR DESCRIPTION
Email is requested at a prompt. This allows us to suggest the previous
email address from the netrc as an option rather than always requiring
the user to enter it, even if they've already done so on a previous
login attempt.

Fixes #109 /cc @dpiddy 
