### PR TITLE
lists for addon services and plans

### DIFF
--- a/hkdist/public/styleguide.html
+++ b/hkdist/public/styleguide.html
@@ -159,6 +159,16 @@
               "comment": "open an addon (extra)"
             },
             {
+              "root": "addon-plans",
+              "arguments": "<service>",
+              "comment": "list addon plans"
+            },
+            {
+              "root": "addon-services",
+              "arguments": "",
+              "comment": "list addon services"
+            },
+            {
               "root": "addons",
               "arguments": "[-a <app>] [<service>:<plan>...]",
               "comment": "list addons"

--- a/main.go
+++ b/main.go
@@ -123,6 +123,8 @@ var commands = []*Command{
 	cmdAccountFeatureEnable,
 	cmdAccountFeatureDisable,
 	cmdAddonOpen,
+	cmdAddonPlans,
+	cmdAddonServices,
 	cmdAPI,
 	cmdCreds,
 	cmdDrains,


### PR DESCRIPTION
I'll need these in order to be able to offer completion of these values.

Examples:

```
$ hk addon-services
heroku-postgresql
newrelic
redisgreen
...

$ hk addon-plans heroku-postgresql
hobby-dev        $0/mo
hobby-basic      $9/mo
standard-yanari  $50/mo
standard-tengu   $200/mo
premium-yanari   $200/mo
premium-tengu    $350/mo
standard-ika     $750/mo
premium-ika      $1200/mo
...
```

/cc @max for design review
