### PR TITLE
move git sha/tag column to end of description

### DIFF
--- a/releases.go
+++ b/releases.go
@@ -23,23 +23,22 @@ var cmdReleases = &Command{
 	Short:    "list releases",
 	Long: `
 Lists releases. Shows the version of the release (e.g. v1), who
-made the release, git commit id, time of the release, and
-description.
+made the release, time of the release, and description.
 
 Examples:
 
     $ hk releases
-    v1  bob@test.com  3ae20c2  Jun 12 18:28  Deploy 3ae20c2
-    v2  john@me.com   0fda0ae  Jun 13 18:14  Deploy 0fda0ae
-    v3  john@me.com            Jun 13 18:31  Rollback to v2
+    v1  bob@test.com  Jun 12 18:28  Deploy 3ae20c2
+    v2  john@me.com   Jun 13 18:14  Deploy 0fda0ae
+    v3  john@me.com   Jun 13 18:31  Rollback to v2
 
     $ hk releases -n 2
-    v2  john  0fda0ae  Jun 13 18:14  Deploy 0fda0ae
-    v3  john           Jun 13 18:31  Rollback to v2
+    v2  john  Jun 13 18:14  Deploy 0fda0ae
+    v3  john  Jun 13 18:31  Rollback to v2
 
     $ hk releases 1 3
-    v1  bob@test.com  3ae20c2  Jun 12 18:28  Deploy 3ae20c2
-    v3  john@me.com            Jun 13 18:31  Rollback to v2
+    v1  bob@test.com  Jun 12 18:28  Deploy 3ae20c2
+    v3  john@me.com   Jun 13 18:31  Rollback to v2
 `,
 }
 
@@ -131,12 +130,17 @@ func abbrevEmailReleases(rels []*Release) {
 }
 
 func listRelease(w io.Writer, r *Release) {
+	desc := r.Description
+	// add the git tag to the description if it's not a hash (and thus isn't
+	// included already)
+	if r.Commit != "" && !strings.Contains(r.Description, r.Commit) {
+		desc += " (" + abbrev(r.Commit, 12) + ")"
+	}
 	listRec(w,
 		fmt.Sprintf("v%d", r.Version),
 		abbrev(r.Who, 10),
-		abbrev(r.Commit, 10),
 		prettyTime{r.CreatedAt},
-		r.Description,
+		desc,
 	)
 }
 


### PR DESCRIPTION
If the git description for the release's hash is not already included in the release's description (and thus isn't just a hash), append it to the end of the description when we display it.

Here's how it looks:

```
➜  hk releases -a hkdist        
v120  b  Jan 22 15:59  Deploy 15146e5
v121  b  Jan 22 16:03  Deploy c11e447
v122  b  Jan 22 16:56  Deploy e236e1b
v123  b  Jan 23 11:47  Deploy 71316e5 (v20140123~5)
v124  b  Jan 23 14:56  Deploy 8089f65 (v20140123~2)
...
v136  b  Feb 11 14:55  Removed IMPORTANT config vars.
v137  b  Feb 25 12:16  Deploy db8dba2 (v20140225)
v138  b  Mar  3 12:45  Attach HEROKU_POSTGRESQL_ORANGE resource
v139  b  Mar  3 12:50  Detach HEROKU_POSTGRESQL_ORANGE resource
v140  b  Mar 11 21:01  Deploy dff5cef (v20140311)
```

Fixes #93. /cc @raul @kr
