### PR TITLE
Clear up instructions for add _hk completions to your shell

### DIFF
--- a/contrib/hk-zsh-completion.sh
+++ b/contrib/hk-zsh-completion.sh
@@ -1,7 +1,8 @@
 #compdef hk
 
-# hk Autocomplete plugin for Oh-My-Zsh. To install it, drop this plugin at
-# /usr/local/share/zsh/site-functions/_hk or another directory in your $fpath.
+# hk Autocomplete plugin for Oh-My-Zsh. To install it, drop this plugin into a
+# file called `_hk` within /usr/local/share/zsh/site-functions or another
+# directory in your $fpath.
 #
 # Requires: The hk Heroku client (https://hk.heroku.com)
 # Author: Blake Gentry (https://bgentry.io)


### PR DESCRIPTION
I found the completion installation instructions a little misleading and therefore couldn't get them working without some lengthy head scratching.  This commit cleans up the copy to make this a little clearer.
