### PR TITLE
git remote host from gitconfig

### DIFF
--- a/git.go
+++ b/git.go
@@ -26,6 +26,9 @@ func gitHost() string {
 	if herokuHost := os.Getenv("HEROKU_HOST"); herokuHost != "" {
 		return herokuHost
 	}
+	if herokuGitConfigHost := hostFromGitConfig(); herokuGitConfigHost != "" {
+		return herokuGitConfigHost
+	}
 	return "heroku.com"
 }
 
@@ -117,6 +120,14 @@ func parseGitRemoteOutput(b []byte) (results map[string]string, err error) {
 
 func remoteFromGitConfig() string {
 	b, err := exec.Command("git", "config", "heroku.remote").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func hostFromGitConfig() string {
+	b, err := exec.Command("git", "config", "heroku.host").Output()
 	if err != nil {
 		return ""
 	}

--- a/git_test.go
+++ b/git_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -23,6 +26,23 @@ func TestGitHost(t *testing.T) {
 	if res := gitHost(); res != "stillnotheroku.com" {
 		t.Errorf("expected stillnotheroku.com, got %s", res)
 	}
+
+	fi, err := ioutil.TempFile("", "config")
+	if err != nil {
+		t.Errorf("expected alsonotheroku.com, but couldn't create temp config file")
+	}
+	if _, err := fi.WriteString("[heroku]\n\thost = alsonotheroku.com\n"); err != nil {
+		t.Errorf("expected alsonotheroku.com, but couldn't write temp config file")
+	}
+	b, _ := exec.Command("git", "config", "--file", fi.Name(), "heroku.host").Output()
+	if res := strings.TrimSpace(string(b)); res != "alsonotheroku.com" {
+		t.Errorf("expected alsonotheroku.com, got %s", res)
+	}
+	defer func() {
+		fi.Close()
+		os.Remove(fi.Name())
+	}()
+
 }
 
 var gitRemoteTestOutput = `


### PR DESCRIPTION
Find a Heroku app remote with a custom hostname from a `heroku.host`
gitconfig. The git host gets picked in this order `HEROKU_GIT_HOST` -> `HEROKU_HOST` -> `heroku.host` in gitconfig -> `heroku.com`

Extends the fix for #49
