### PR TITLE
Add trailing newline to last printed message for pg-unfollow

### DIFF
--- a/pg.go
+++ b/pg.go
@@ -245,7 +245,7 @@ func runPgUnfollow(cmd *Command, args []string) {
 	mustConfirm(warning, args[0])
 
 	must(db.Unfollow())
-	fmt.Printf("Unfollowed %s on %s.", addonName, appname)
+	fmt.Printf("Unfollowed %s on %s.\n", addonName, appname)
 }
 
 var commandNamePsql string


### PR DESCRIPTION
Otherwise, the shell prompt would be printed immediately after the
message.
