### PR TITLE
Try to use HOME environment value first on Windows.

### DIFF
--- a/hkclient/windows.go
+++ b/hkclient/windows.go
@@ -7,7 +7,10 @@ import "os"
 const netrcFilename = "_netrc"
 
 func homePath() string {
-	home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	}
 	if home == "" {
 		home = os.Getenv("USERPROFILE")
 	}


### PR DESCRIPTION
On Windows + MinGW/MSYS envrionment,
it seems base system of MSYS rewrites HOMEPATH environment value.
For example, `\Users\koron` -> `\` on my environment.
Therefore, HOMEDRIVE + HOMEPATH is evaluated as `C:\` and be used as home directory,
where normal users don't have any rights to write.

I have created this evasive change, and I know it is not good solution.
But I don't have any better idea for now.
