### PR TITLE
use os/user to determine home directory on Windows

### DIFF
--- a/hkclient/windows.go
+++ b/hkclient/windows.go
@@ -2,14 +2,17 @@
 
 package hkclient
 
-import "os"
+import (
+	"log"
+	"os/user"
+)
 
 const netrcFilename = "_netrc"
 
 func homePath() string {
-	home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-	if home == "" {
-		home = os.Getenv("USERPROFILE")
+	u, err := user.Current()
+	if err != nil {
+		log.Fatal(err)
 	}
-	return home
+	return u.HomeDir
 }

--- a/windows.go
+++ b/windows.go
@@ -3,8 +3,10 @@
 package main
 
 import (
+	"log"
 	"os"
 	"os/exec"
+	"os/user"
 )
 
 const (
@@ -27,9 +29,9 @@ func sysExec(path string, args []string, env []string) error {
 }
 
 func homePath() string {
-	home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-	if home == "" {
-		home = os.Getenv("USERPROFILE")
+	u, err := user.Current()
+	if err != nil {
+		log.Fatal(err)
 	}
-	return home
+	return u.HomeDir
 }


### PR DESCRIPTION
As I reported in #140, `homePath()` is not perfect for Windows (+MSYS).
And old issue #7 and 2e314c66c2c084dc8a110119cccea40f04077c11 had solved it by using `os/user` package.
But those changes are lost imperceptibly.

This pull request uses `os/user` again to determine homePath.
