### PR TITLE
printFatal on hkclient.New() error.

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func initClients() {
 	loadNetrc()
 	suite, err := hkclient.New(nrc, hkAgent)
 	if err != nil {
-		printError(err.Error())
+		printFatal(err.Error())
 	}
 
 	client = suite.Client


### PR DESCRIPTION
Fixes heroku/hk#162.
