### PR TITLE
Fix `hk log` under heroku-agent; don't mutate `http.DefaultTransport`

### DIFF
--- a/hkclient/client.go
+++ b/hkclient/client.go
@@ -55,7 +55,7 @@ func New(nrc *NetRc, agent string) (*Clients, error) {
 		Debug:     debug,
 	}
 
-	tr := http.DefaultTransport.(*http.Transport)
+	tr := &http.Transport{}
 	ste.Client.HTTP = &http.Client{Transport: tr}
 	ste.PgClient.HTTP = &http.Client{Transport: tr}
 


### PR DESCRIPTION
Unfortunately, having `HEROKU_AGENT_SOCK` set currently breaks `hk log` 
because I overwrite the default `Dial` function. When `hk log` tries to 
retrieve the URL for its log session, it can no longer perform a normal HTTPS
call properly.

This patches that issue by making `tr` just define a new transport which it
will then use for calls to the Heroku API and PG APIs. Even in devclouds,
setting `TLSClientConfig` should only be required for calls to the API, so I
don't _think_ that this will have any negative side effects on the program.
