### PR TITLE
Authenticate like the Heroku CLI

### DIFF
--- a/Godeps/_workspace/src/github.com/bgentry/heroku-go/heroku.go
+++ b/Godeps/_workspace/src/github.com/bgentry/heroku-go/heroku.go
@@ -152,7 +152,7 @@ func (c *Client) NewRequest(method, path string, body interface{}) (*http.Reques
 	if ctype != "" {
 		req.Header.Set("Content-Type", ctype)
 	}
-	req.SetBasicAuth(c.Username, c.Password)
+	req.SetBasicAuth("", c.Password)
 	for k, v := range c.AdditionalHeaders {
 		req.Header[k] = v
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -92,7 +92,7 @@ func execPlugin(path string, args []string) error {
 	}
 
 	hkuser, hkpass := getCreds(apiURL)
-	u.User = url.UserPassword(hkuser, hkpass)
+	u.User = url.UserPassword("", hkpass)
 	hkapp, _ := app()
 	env := []string{
 		"HEROKU_API_URL=" + u.String(),

--- a/postgresql/client.go
+++ b/postgresql/client.go
@@ -129,7 +129,7 @@ func (c *Client) NewRequest(isStarterPlan bool, method, path string) (*http.Requ
 		useragent = DefaultUserAgent
 	}
 	req.Header.Set("User-Agent", useragent)
-	req.SetBasicAuth(c.Username, c.Password)
+	req.SetBasicAuth("", c.Password)
 	for k, v := range c.AdditionalHeaders {
 		req.Header[k] = v
 	}


### PR DESCRIPTION
The Heroku API accepts a number of different authentication schemes:
1. `Authorization: Bearer <token>`
2. `Authorization: Basic <base64 encoded ":<token>">`
3. `Authorization: Basic <base64 encoded "<email>:<token>">`
4. `Authorization: Basic <base64 encoded "<email>:<password>">`

Currently, the CLI uses the scheme 2 while hk uses scheme 3. This pull changes
hk over to the same scheme used by the CLI (that's scheme 2).

Moving over mainly carries the benefit of intermediaries being able to tell
that two authentication schemes are equivalent and consolidate them. Scheme 2
also has the nice property of being distiguishable from scheme 4, which helps
intermediaries differentiate token-based authentication from password-based.

~~I'll open an equivalent pull on the heroku.go dependency.~~ bgentry/heroku-go#13
