### PR TITLE
Support HTTP git.

### DIFF
--- a/create.go
+++ b/create.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	"log"
-	"os/exec"
 
 	"github.com/bgentry/heroku-go"
 )
 
 var cmdCreate = &Command{
 	Run:      runCreate,
-	Usage:    "create [-r <region>] [-o <org>] [<name>]",
+	Usage:    "create [-r <region>] [-o <org>] [--http-git] [<name>]",
 	Category: "app",
 	Short:    "create an app",
 	Long: `
@@ -34,10 +33,12 @@ Examples:
 
 var flagRegion string
 var flagOrgName string
+var flagHTTPGit bool
 
 func init() {
 	cmdCreate.Flag.StringVarP(&flagRegion, "region", "r", "", "region name")
 	cmdCreate.Flag.StringVarP(&flagOrgName, "org", "o", "", "organization name")
+	cmdCreate.Flag.BoolVar(&flagHTTPGit, "http-git", false, "use http git remote")
 }
 
 func runCreate(cmd *Command, args []string) {
@@ -62,7 +63,8 @@ func runCreate(cmd *Command, args []string) {
 
 	app, err := client.OrganizationAppCreate(&opts)
 	must(err)
-	exec.Command("git", "remote", "add", "heroku", app.GitURL).Run()
+
+	addGitRemote(app, flagHTTPGit)
 
 	if app.Organization != nil {
 		log.Printf("Created %s in the %s org.", app.Name, app.Organization.Name)

--- a/git_test.go
+++ b/git_test.go
@@ -32,6 +32,8 @@ staging	git@heroku.com:myapp-staging.git (fetch)
 staging	git@heroku.com:myapp-staging.git (push)
 origin	git@github.com:heroku/hk.git (fetch)
 origin	git@github.com:heroku/hk.git (push)
+exciting	https://git.heroku.com/amazing.git (fetch)
+exciting	https://git.heroku.com/amazing.git (push)
 `
 
 func TestParseGitRemoteOutput(t *testing.T) {
@@ -41,8 +43,9 @@ func TestParseGitRemoteOutput(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"heroku":  "myapp",
-		"staging": "myapp-staging",
+		"heroku":   "myapp",
+		"staging":  "myapp-staging",
+		"exciting": "amazing",
 	}
 
 	if len(results) != len(expected) {


### PR DESCRIPTION
create takes `--http-git` and respects `HEROKU_HTTP_GIT_ALWAYS` in the environment when creating the `heroku` git remote.

HTTP-git using remotes are detected and used like ssh git remotes.
