### PR TITLE
zsh auto-complete app name in addon-open

### DIFF
--- a/contrib/hk-zsh-completion.sh
+++ b/contrib/hk-zsh-completion.sh
@@ -322,6 +322,12 @@ _hk-addon-destroy() {
   _hk_complete_only_app_flag
 }
 
+_hk-addon-open() {
+  # TODO: complete addon name argument
+  local curcontext=$curcontext state line ret=1
+  _hk_complete_only_app_flag
+}
+
 _hk-addon-plan() {
   # TODO: other optional args besides app flag
   local curcontext=$curcontext state line ret=1


### PR DESCRIPTION
Somehow I missed this command when adding basic auto-completion handlers. This at least completes the `-a` / `--app` argument, though not the addon's name as that would require per-app resolving of addon lists.
