### PR TITLE
Add info about how to stop a 'hk run' dyno

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -464,7 +464,7 @@ hk regions                                                        # list regions
 hk release-info [-a <app>] <version>                              # show release info
 hk releases [-a <app>] [-n <limit>] [<version>...]                # list releases
 hk rename <oldname> <newname>                                     # rename an app
-hk restart [-a <app>] [<type or name>]                            # restart dynos
+hk restart [-a <app>] [<type or name>]                            # restart dynos (or stop a dyno started with 'hk run')
 hk rollback [-a <app>] <version>                                  # roll back to a previous release
 hk run [-s <size>] [-d] <command> [<argument>...]                 # run a process in a dyno
 hk scale [-a <app>] <type>=[<qty>]:[<size>]...                    # change dyno quantities and sizes

--- a/hkdist/public/styleguide.html
+++ b/hkdist/public/styleguide.html
@@ -366,7 +366,7 @@
             {
               "root": "restart",
               "arguments": "[-a <app or remote>] [<type or name>]",
-              "comment": "restart dynos"
+              "comment": "restart dynos (or stop a dyno started with 'hk run')"
             },
             {
               "root": "run",

--- a/restart.go
+++ b/restart.go
@@ -11,9 +11,10 @@ var cmdRestart = &Command{
 	Usage:    "restart [<type or name>]",
 	NeedsApp: true,
 	Category: "dyno",
-	Short:    "restart dynos",
+	Short:    "restart dynos (or stop a dyno started with 'hk run')",
 	Long: `
-Restart all app dynos, all dynos of a specific type, or a single dyno.
+Restart all app dynos, all dynos of a specific type, or a single dyno. If used
+on a dyno started using 'hk run' this will effectively stop it.
 
 Examples:
 


### PR DESCRIPTION
Closes #187 

If a dyne is running which is started using the `hk run` command, it's not obvious from the documentation how to stop it again. This PR should make it more clear.