### PR TITLE
Properly set apiURL to the value in the HEROKU_API_URL environment variable.

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func initClients() {
 
 	client = suite.Client
 	pgclient = suite.PgClient
-
+	apiURL = suite.ApiURL
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -95,6 +95,10 @@ func TestHerokuAPIURL(t *testing.T) {
 		t.Errorf("expected client.URL to be %q, got %q", newURL, client.URL)
 	}
 
+	if apiURL != newURL {
+		t.Errorf("expected apiURL to be %q, got %q", newURL, apiURL)
+	}
+
 	// cleanup
 	os.Setenv("HEROKU_API_URL", "")
 }


### PR DESCRIPTION
Prior to this change, when setting a custom HEROKU_API_URL environment variable, then exec'ing a plugin would result in the default `http://api.heroku.com` being passed to the plugin (actually, multiple `HEROKU_API_URL`'s get passed, because the original environment is [appended](https://github.com/heroku/hk/blob/6d62fd68b5c472d56f4dedc854e80d81487dc495/plugin.go#L106)).