### PR TITLE
Stores the port if given in netrc

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -140,7 +140,7 @@ func runLogin(cmd *Command, args []string) {
 		printFatal(err.Error())
 	}
 
-	hostname, token, err := attemptLogin(email, password, "")
+	address, token, err := attemptLogin(email, password, "")
 	if err != nil {
 		if herror, ok := err.(heroku.Error); ok && herror.Id == "two_factor" {
 			// 2FA requested, attempt 2FA login
@@ -149,7 +149,7 @@ func runLogin(cmd *Command, args []string) {
 			if _, err := fmt.Scanln(&twoFactorCode); err != nil {
 				printFatal("reading two-factor auth code: " + err.Error())
 			}
-			hostname, token, err = attemptLogin(email, password, twoFactorCode)
+			address, token, err = attemptLogin(email, password, twoFactorCode)
 			must(err)
 		} else {
 			must(err)
@@ -161,7 +161,7 @@ func runLogin(cmd *Command, args []string) {
 		printFatal("loading netrc: " + err.Error())
 	}
 
-	err = nrc.SaveCreds(hostname, email, token)
+	err = nrc.SaveCreds(address, email, token)
 	if err != nil {
 		printFatal("saving new token: " + err.Error())
 	}
@@ -202,7 +202,7 @@ func attemptLogin(username, password, twoFactorCode string) (hostname, token str
 	if auth.AccessToken == nil {
 		return "", "", fmt.Errorf("access token missing from Heroku API login response")
 	}
-	return strings.Split(req.Host, ":")[0], auth.AccessToken.Token, nil
+	return req.Host, auth.AccessToken.Token, nil
 }
 
 var cmdLogout = &Command{

--- a/hkclient/creds.go
+++ b/hkclient/creds.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/heroku/hk/Godeps/_workspace/src/github.com/bgentry/go-netrc/netrc"
 )
@@ -55,8 +54,7 @@ func (nrc *NetRc) GetCreds(apiURL *url.URL) (user, pass string, err error) {
 }
 
 func (nrc *NetRc) SaveCreds(address, user, pass string) error {
-	host := strings.Split(address, ":")[0]
-	m := nrc.FindMachine(host)
+	m := nrc.FindMachine(address)
 	if m == nil || m.IsDefault() {
 		m = nrc.NewMachine(address, user, pass, "")
 	}

--- a/hkclient/creds.go
+++ b/hkclient/creds.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/heroku/hk/Godeps/_workspace/src/github.com/bgentry/go-netrc/netrc"
 )
@@ -53,10 +54,11 @@ func (nrc *NetRc) GetCreds(apiURL *url.URL) (user, pass string, err error) {
 	return m.Login, m.Password, nil
 }
 
-func (nrc *NetRc) SaveCreds(host, user, pass string) error {
+func (nrc *NetRc) SaveCreds(address, user, pass string) error {
+	host := strings.Split(address, ":")[0]
 	m := nrc.FindMachine(host)
 	if m == nil || m.IsDefault() {
-		m = nrc.NewMachine(host, user, pass, "")
+		m = nrc.NewMachine(address, user, pass, "")
 	}
 	m.UpdateLogin(user)
 	m.UpdatePassword(pass)


### PR DESCRIPTION
Before if you set your HEROKU_API_URL to include a port when it went to
save the creds in ~/.netrc it would drop the port. Now it keeps it.